### PR TITLE
Documentation: Update link for forms documentation

### DIFF
--- a/doc/providers/form.rst
+++ b/doc/providers/form.rst
@@ -201,4 +201,4 @@ Traits
     $app->form($data);
 
 For more information, consult the `Symfony Forms documentation
-<http://symfony.com/doc/2.3/book/forms.html>`_.
+<http://symfony.com/doc/3.0/book/forms.html>`_.


### PR DESCRIPTION
Update the link to the forms documentation to reflect 3.0. The code example in this file was already updated in #1302

Have used 3.0 instead of current to allow for possible future BC changes.